### PR TITLE
Transfer develop branch from external testing repo

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -11,6 +11,7 @@ from ckanext.validation.ontario_data_standards.header_rule_2_2_header_length imp
 from ckanext.validation.ontario_data_standards.header_rule_2_3_snake_case import header_rule_2_3_snake_case
 from ckanext.validation.ontario_data_standards.header_rule_2_4_first_char import header_rule_2_4_first_char
 from ckanext.validation.ontario_data_standards.data_entry_rule_2_6_bullet_lists import data_entry_rule_2_6_bullet_lists
+from ckanext.validation.ontario_data_standards.data_entry_rule_4_7_bare_numbers import data_entry_rule_4_7_bare_numbers
 #from frictionless.errors.table import TableError
 
 from ckan.model import Session
@@ -179,7 +180,9 @@ def _validate_table(source, _format='csv', schema=None, **options):
                           checks=[header_rule_2_2_header_length(),
                                   header_rule_2_3_snake_case(),
                                   header_rule_2_4_first_char(),
-                                  data_entry_rule_2_6_bullet_lists()])
+                                  data_entry_rule_2_6_bullet_lists(),
+                                  data_entry_rule_4_7_bare_numbers()
+                                 ])
         log.debug('Validating source: %s', source)
 
     return report

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -87,13 +87,6 @@ def run_validation_job(resource):
         schema = resource.get('ui_dict')
     else:
         schema = resource.get('schema')
-    # schema = resource.get('schema')
-    # if schema:
-    #     if isinstance(schema, str):
-    #         if schema.startswith('http'):
-    #             r = requests.get(schema)
-    #             schema = r.json()
-    #         schema = json.loads(schema)
 
     _format = resource['format'].lower()
     report = _validate_table(source, _format=_format, schema=schema, **options)
@@ -172,8 +165,6 @@ def _validate_table(source, _format='csv', schema=None, **options):
         options['checks'] = checklist
 
     with system.use_context(**frictionless_context):
-        #report = validate(source, format=_format, schema=resource_schema, **options)
-        # FOR TESTING ONLY!!!
         report = validate(source, 
                           format=_format, 
                           schema=resource_schema,

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -174,7 +174,8 @@ def _validate_table(source, _format='csv', schema=None, **options):
                           schema=resource_schema,
                           checks=[header_rule_2_2_header_length(),
                                   header_rule_2_3_snake_case(),
-                                  header_rule_2_4_underscore()])
+                                  header_rule_2_4_underscore(),
+                                  data_entry_rule_2_6_bullet_lists()])
         log.debug('Validating source: %s', source)
 
     return report
@@ -259,3 +260,19 @@ class header_rule_2_4_underscore(Check):
                                                 field_number=field_number+1,
                                                 field_name=header)
 
+# Data entry rules
+class data_entry_rule_2_6_bullet_lists(Check):
+    ''' 
+    Cell value cannot contain a bullet list. 
+    '''
+    Errors = [errors.ForbiddenValueError]
+    def validate_row(self, row):
+        for header in list(row):
+            this_cell = row[header]
+            list_chars = [u'•', u'*', u'- ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash
+            bullet_check = [ele for ele in list_chars if(ele in this_cell)]
+            if len(bullet_check) > 0:
+                note = 'Cell value cannot contain bullets, dashes, new line or tab characters. Please make separate rows.'
+                yield errors.ForbiddenValueError.from_row(row, 
+                                                        note=note,
+                                                        field_name=header)

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -174,7 +174,7 @@ def _validate_table(source, _format='csv', schema=None, **options):
                           schema=resource_schema,
                           checks=[header_rule_2_2_header_length(),
                                   header_rule_2_3_snake_case(),
-                                  header_rule_2_4_underscore(),
+                                  header_rule_2_4_first_char(),
                                   data_entry_rule_2_6_bullet_lists()])
         log.debug('Validating source: %s', source)
 
@@ -244,7 +244,7 @@ class header_rule_2_3_snake_case(Check):
                                                 field_number=field_number+1,
                                                 field_name=header)
 
-class header_rule_2_4_underscore(Check):
+class header_rule_2_4_first_char(Check):
     ''' 
     Column headers must begin with an alphabetic letter. 
     '''
@@ -263,16 +263,18 @@ class header_rule_2_4_underscore(Check):
 # Data entry rules
 class data_entry_rule_2_6_bullet_lists(Check):
     ''' 
-    Cell value cannot contain a bullet list. 
+    Cell value cannot contain a bullet list.
+    Skip check for non-string cells.
     '''
     Errors = [errors.ForbiddenValueError]
     def validate_row(self, row):
         for header in list(row):
             this_cell = row[header]
-            list_chars = [u'•', u'*', u'- ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash
-            bullet_check = [ele for ele in list_chars if(ele in this_cell)]
-            if len(bullet_check) > 0:
-                note = 'Cell value cannot contain bullets, dashes, new line or tab characters. Please make separate rows.'
-                yield errors.ForbiddenValueError.from_row(row, 
-                                                        note=note,
-                                                        field_name=header)
+            if isinstance(this_cell, str):
+                list_chars = [u'•', u'* ', u'- ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash
+                bullet_check = [ele for ele in list_chars if(ele in this_cell.rstrip())] # strip any trailing spaces
+                if len(bullet_check) > 0:
+                    note = 'Cell value cannot contain bullets, dashes, new line or tab characters. Please make separate rows.'
+                    yield errors.ForbiddenValueError.from_row(row, 
+                                                            note=note,
+                                                            field_name=header)

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -245,13 +245,13 @@ class header_rule_2_3_snake_case(Check):
 
 class header_rule_2_4_underscore(Check):
     ''' 
-    Column headers must not begin with an underscore. 
+    Column headers must begin with an alphabetic letter. 
     '''
     Errors = [errors.ForbiddenLabelError]
     def validate_row(self, row):
         for field_number, header in enumerate(list(row)):
-            if header[0]=='_':
-                note = 'Column name cannot begin with an underscore.'
+            if not header[0].isalpha():
+                note = 'Column name must begin with an alphabetic letter.'
                 yield errors.ForbiddenLabelError(note=note, 
                                                 row_numbers=list(range(1,len(list(row))+1)),
                                                 label=header,

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -174,7 +174,11 @@ def _validate_table(source, _format='csv', schema=None, **options):
     with system.use_context(**frictionless_context):
         #report = validate(source, format=_format, schema=resource_schema, **options)
         # FOR TESTING ONLY!!!
-        report = validate(source, format=_format, schema=resource_schema, checks=[header_rule_2_4_underscore()])
+        report = validate(source, 
+                          format=_format, 
+                          schema=resource_schema, 
+                          checks=[header_rule_2_3_snake_case(),
+                                  header_rule_2_4_underscore()])
         log.debug('Validating source: %s', source)
 
     return report
@@ -188,12 +192,29 @@ def _get_site_user_api_key():
     return site_user['apikey']
 
 # Custom checks
+class header_rule_2_3_snake_case(Check):
+    ''' Column headers must be in snake case. 
+    Requirements to satisfy snake_case:
+       * it's composed only by lowercase letters ([a-z]), underscores 
+         and optionally numbers ([0-9])
+       * it does not start/end with an underscore (or provided separator)
+       * it does not start with a number
+    '''
+    Errors = [errors.CellError]
+    def validate_row(self, row):
+        print('HEJ jobs py row in rule 2 3: ', row)
+        for header in list(row):
+            if bool(re.search(r"\s", header)):
+                note = 'Column headers cannot contain spaces, they must follow snake_case pattern.'
+                print('HEJ jobs py violaion found rule 2 3!: ', note)
+                yield errors.CellError.from_row(row, note=note, field_name=header)
+
 class header_rule_2_4_underscore(Check):
     Errors = [errors.CellError]
     def validate_row(self, row):
-        print('HEJ jobs py row: ', row)
+        print('HEJ jobs py row in rule 2 4: ', row)
         for header in list(row):
             if header[0]=='_':
-                note = 'Column header cannot begin with an underscore'
-                print('HEJ jobs py violaion found!: ', note)
+                note = 'Column header cannot begin with an underscore.'
+                print('HEJ jobs py violaion found rule 2 4!: ', note)
                 yield errors.CellError.from_row(row, note=note, field_name=header)

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -40,17 +40,14 @@ def run_validation_job(resource):
 
     options = t.config.get(
         'ckanext.validation.default_validation_options')
-    print('HEJ jobs py options: ', options)
     #options = {"checks": [header_rule_2_4_underscore()]}
     #
     if options:
         options = json.loads(options)
     else:
         options = {}
-    print('HEJ jobs py options after json loads: ', options)
 
     resource_options = resource.get('validation_options')
-    print('HEJ jobs py resource_options: ', resource_options)
     if resource_options and isinstance(resource_options, str):
         resource_options = json.loads(resource_options)
     if resource_options:
@@ -176,9 +173,8 @@ def _validate_table(source, _format='csv', schema=None, **options):
         # FOR TESTING ONLY!!!
         report = validate(source, 
                           format=_format, 
-                          schema=resource_schema, 
-                          checks=[header_rule_2_3_snake_case(),
-                                  header_rule_2_4_underscore()])
+                          schema=resource_schema,
+                        checks=[header_rule_2_4_underscore()])
         log.debug('Validating source: %s', source)
 
     return report
@@ -191,30 +187,27 @@ def _get_site_user_api_key():
         {'ignore_auth': True}, {'id': site_user_name})
     return site_user['apikey']
 
-# Custom checks
-class header_rule_2_3_snake_case(Check):
-    ''' Column headers must be in snake case. 
-    Requirements to satisfy snake_case:
-       * it's composed only by lowercase letters ([a-z]), underscores 
-         and optionally numbers ([0-9])
-       * it does not start/end with an underscore (or provided separator)
-       * it does not start with a number
-    '''
-    Errors = [errors.CellError]
-    def validate_row(self, row):
-        print('HEJ jobs py row in rule 2 3: ', row)
-        for header in list(row):
-            if bool(re.search(r"\s", header)):
-                note = 'Column headers cannot contain spaces, they must follow snake_case pattern.'
-                print('HEJ jobs py violaion found rule 2 3!: ', note)
-                yield errors.CellError.from_row(row, note=note, field_name=header)
 
+# WORKS AS A CellError using custom class in frictionless errors/cell.py
+# class header_rule_2_4_underscore(Check):
+#     Errors = [errors.ForbiddenHeaderError]
+#     def validate_row(self, row):
+#         for header in list(row):
+#             if header[0]=='_':
+#                 note = 'Column header cannot begin with an underscore.'
+#                 yield errors.ForbiddenHeaderError.from_row(row, note=note, field_name=header)
+
+# Define custom LabelError checks for header rules.
+# Uses custom class ForbiddenLabelError in frictionless errors/label.py
 class header_rule_2_4_underscore(Check):
-    Errors = [errors.CellError]
+    Errors = [errors.ForbiddenLabelError]
     def validate_row(self, row):
-        print('HEJ jobs py row in rule 2 4: ', row)
-        for header in list(row):
+        for field_number, header in enumerate(list(row)):
             if header[0]=='_':
-                note = 'Column header cannot begin with an underscore.'
-                print('HEJ jobs py violaion found rule 2 4!: ', note)
-                yield errors.CellError.from_row(row, note=note, field_name=header)
+                note = 'Column name cannot begin with an underscore.'
+                yield errors.ForbiddenLabelError(note=note, 
+                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                label=header,
+                                                labels=list(row),
+                                                field_number=field_number+1,
+                                                field_name=header)

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -76,14 +76,19 @@ def run_validation_job(resource):
 
     if not source:
         source = resource['url']
-
-    schema = resource.get('schema')
-    if schema:
-        if isinstance(schema, str):
-            if schema.startswith('http'):
-                r = requests.get(schema)
-                schema = r.json()
-            schema = json.loads(schema)
+    
+    # If the CKAN UI dict has been passed in, assign it to schema
+    if 'ui_dict' in resource and len(resource['ui_dict']) > 0:
+        schema = resource.get('ui_dict')
+    else:
+        schema = resource.get('schema')
+    # schema = resource.get('schema')
+    # if schema:
+    #     if isinstance(schema, str):
+    #         if schema.startswith('http'):
+    #             r = requests.get(schema)
+    #             schema = r.json()
+    #         schema = json.loads(schema)
 
     _format = resource['format'].lower()
     report = _validate_table(source, _format=_format, schema=schema, **options)

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -675,7 +675,6 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
         report = json.loads(validation['report'])
 
         if not report['valid']:
-
             # Delete validation object
             t.get_action(u'resource_validation_delete')(
                 {u'ignore_auth': True},
@@ -685,13 +684,6 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
             # Delete uploaded file
             if local_upload:
                 delete_local_uploaded_file(resource_id)
-
-            if new_resource:
-                # Delete resource
-                t.get_action(u'resource_delete')(
-                    {u'ignore_auth': True, 'user': None},
-                    {u'id': resource_id}
-                )
 
             raise t.ValidationError({
                 u'validation': [report]})

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -88,6 +88,10 @@ def resource_validation_run(context, data_dict):
     resource = t.get_action(u'resource_show')(
         {}, {u'id': data_dict[u'resource_id']})
 
+    # Append CKAN UI dict to resource if it has been passed in
+    if 'ui_dict' in data_dict and len(data_dict['ui_dict']) > 0:
+        resource['ui_dict'] = data_dict['ui_dict']
+
     # TODO: limit to sysadmins
     async_job = data_dict.get(u'async', True)
 

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -675,7 +675,6 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
         report = json.loads(validation['report'])
 
         if not report['valid']:
-
             # Delete validation object
             t.get_action(u'resource_validation_delete')(
                 {u'ignore_auth': True},
@@ -687,11 +686,15 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
                 delete_local_uploaded_file(resource_id)
 
             if new_resource:
-                # Delete resource
-                t.get_action(u'resource_delete')(
-                    {u'ignore_auth': True, 'user': None},
-                    {u'id': resource_id}
-                )
+                try:
+                    # Delete resource
+                    t.get_action(u'resource_delete')(
+                        {u'ignore_auth': True, 'user': None},
+                        {u'id': resource_id}
+                    )
+                except NoResultFound:
+                    raise t.ObjectNotFound(
+                    'This resource does not exist in the datastore')
 
             raise t.ValidationError({
                 u'validation': [report]})

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -707,8 +707,8 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
 def get_datastore_info(resource_id):
     ''' Gets the CKAN UI data dictionary array of
     an existing resource if it has been submitted,
-    and returns it in the format used by ckanext-validation
-    with data types conforming to Frictionless Data.
+    and fetches the Frictionless dictionary previously
+    stored on the columns.
 
     In the case of existing resources that get updated with a 
     new file but that do not have a CKAN UI dictionary (i.e. 
@@ -725,19 +725,22 @@ def get_datastore_info(resource_id):
 
     schema_obj = {}
     new_fields = []
+
     for el in raw_dict:
-        if el['id'] == '_id':
-            el['type'] = 'integer' # for some reason, the _id type is "int"
-        else:
-            el['name'] = el['id']
-            del el['id']
+        if el['id'] != '_id':
             if 'info' in el:
-                el['type'] = el['info']['frictionless_type']
-                del el['info']
-            else: # UI Dictionary form has not been submitted therefore datastore_search has no attached dict
+                this_el = el['info']['frictionless_dict'][0]
+                new_fields.append(this_el)
+            # UI Dictionary form has not been 
+            # submitted therefore datastore_search
+            # has no attached dict
+            else: 
+                el['name'] = el['id']
+                del el['id']
                 if el['type'] == 'text':
                     el['type'] = 'string'
-            new_fields.append(el)
+                    new_fields.append(el)
+
     schema_obj['fields'] = new_fields
 
     return schema_obj

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -649,8 +649,11 @@ def resource_update(up_func, context, data_dict):
 def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
 
     try:
-        # Get the CKAN UI dict
-        ui_dict = get_datastore_info(resource_id)
+        if new_resource == True:
+            ui_dict = []
+        else:
+            # Get the CKAN UI dict
+            ui_dict = get_datastore_info(resource_id)
 
         t.get_action(u'resource_validation_run')(
             {u'ignore_auth': True},
@@ -699,13 +702,14 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
 
 ## CUSTOM EDITS
 def get_datastore_info(resource_id):
-    ''' Gets the CKAN UI data dictionary array and returns
-     it in the format used by ckanext-validation with
-     data types conforming to Frictionless Data.
+    ''' Gets the CKAN UI data dictionary array of
+    an existing resource and returns it in the format
+    used by ckanext-validation with data types
+    conforming to Frictionless Data.
 
-     '''
+    '''
     info=t.get_action('datastore_search')(
-                data_dict={'id': resource_id})
+            data_dict={'id': resource_id})
 
     return reformat_ui_dict(info['fields'])
 

--- a/ckanext/validation/ontario_data_standards/data_entry_rule_2_6_bullet_lists.py
+++ b/ckanext/validation/ontario_data_standards/data_entry_rule_2_6_bullet_lists.py
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+from frictionless import Check, errors
+
+class data_entry_rule_2_6_bullet_lists(Check):
+    ''' 
+    Cell value cannot contain a bullet list.
+    Skip check for non-string cells.
+    '''
+    Errors = [errors.ForbiddenValueError]
+    def validate_row(self, row):
+        for header in list(row):
+            this_cell = row[header]
+            if isinstance(this_cell, str):
+                list_chars = [u'•', u'* ', u'- ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash
+                bullet_check = [ele for ele in list_chars if(ele in this_cell.rstrip())] # strip any trailing spaces
+                if len(bullet_check) > 0:
+                    note = 'Cell value cannot contain bullets, dashes, new line or tab characters. Please make separate rows.'
+                    yield errors.ForbiddenValueError.from_row(row, 
+                                                            note=note,
+                                                            field_name=header)

--- a/ckanext/validation/ontario_data_standards/data_entry_rule_4_7_bare_numbers.py
+++ b/ckanext/validation/ontario_data_standards/data_entry_rule_4_7_bare_numbers.py
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+from frictionless import Check, errors
+
+class data_entry_rule_4_7_bare_numbers(Check):
+    ''' 
+    Numeric cell values should be bare numbers.
+    Current checks:
+    - currency ("$")
+    '''
+    Errors = [errors.ForbiddenValueError]
+    def validate_row(self, row):
+        list_chars = [u'$']
+        for header in list(row):
+            note = []
+            this_cell = row[header]
+            if isinstance(this_cell, str) and [ele for ele in list_chars if(ele in this_cell)]:
+                try:
+                    if float(this_cell.strip("$").strip()):
+                        note = 'Numeric cell values must be a bare number. Please strip the number of its unit and add the unit to the column name.'
+                except ValueError:
+                    pass
+
+                if len(note) > 0:
+                    yield errors.ForbiddenValueError.from_row(row, 
+                                                            note=note,
+                                                            field_name=header)
+                

--- a/ckanext/validation/ontario_data_standards/header_rule_2_2_header_length.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_2_header_length.py
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+from frictionless import Check, errors
+
+class header_rule_2_2_header_length(Check):
+    ''' 
+    Column headers must be less than 63 characters long (PostgreSQL limit). 
+    '''
+    Errors = [errors.ForbiddenLabelError]
+    def validate_row(self, row):
+        note = 'Column name must be less than 63 characters long.'
+        for field_number, header in enumerate(list(row)):
+            if len(header) > 63:
+                yield errors.ForbiddenLabelError(note=note, 
+                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                label=header,
+                                                labels=list(row),
+                                                field_number=field_number+1,
+                                                field_name=header)

--- a/ckanext/validation/ontario_data_standards/header_rule_2_2_header_length.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_2_header_length.py
@@ -7,13 +7,14 @@ class header_rule_2_2_header_length(Check):
     Column headers must be less than 63 characters long (PostgreSQL limit). 
     '''
     Errors = [errors.ForbiddenLabelError]
-    def validate_row(self, row):
+    def validate_start(self):
+        headers = self.resource.labels
         note = 'Column name must be less than 63 characters long.'
-        for field_number, header in enumerate(list(row)):
+        for field_number, header in enumerate(headers):
             if len(header) > 63:
                 yield errors.ForbiddenLabelError(note=note, 
-                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                row_numbers=list(range(1,len(headers)+1)),
                                                 label=header,
-                                                labels=list(row),
+                                                labels=headers,
                                                 field_number=field_number+1,
                                                 field_name=header)

--- a/ckanext/validation/ontario_data_standards/header_rule_2_3_snake_case.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_3_snake_case.py
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+import re
+from frictionless import Check, errors
+
+class header_rule_2_3_snake_case(Check):
+    ''' 
+    Column headers must be in snake case. 
+    Requirements to satisfy snake_case:
+        * header name composed only by lowercase letters ([a-z])
+        * multiple words separated by underscore
+    '''
+    Errors = [errors.ForbiddenLabelError]
+    def validate_row(self, row):
+        note = 'Column name must all be in lower case, and for multiple words, separate them with an underscore.'
+        for field_number, header in enumerate(list(row)):
+            is_valid = []
+            if bool(re.search(r"\s", header)):
+                is_valid.append(False)
+                
+            else:
+                for el in header:
+                    if el.isupper():
+                        is_valid.append(False)
+                        
+
+            if len(list(filter(lambda x: (x == False), is_valid))) > 0:    
+                yield errors.ForbiddenLabelError(note=note, 
+                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                label=header,
+                                                labels=list(row),
+                                                field_number=field_number+1,
+                                                field_name=header)

--- a/ckanext/validation/ontario_data_standards/header_rule_2_3_snake_case.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_3_snake_case.py
@@ -11,23 +11,26 @@ class header_rule_2_3_snake_case(Check):
         * multiple words separated by underscore
     '''
     Errors = [errors.ForbiddenLabelError]
-    def validate_row(self, row):
+    def validate_start(self):
+        headers = self.resource.labels
+   
         note = 'Column name must all be in lower case, and for multiple words, separate them with an underscore.'
-        for field_number, header in enumerate(list(row)):
+        for field_number, header in enumerate(headers):
             is_valid = []
+            # Check for spaces:
             if bool(re.search(r"\s", header)):
                 is_valid.append(False)
                 
-            else:
+            else: # Check for upper case
                 for el in header:
                     if el.isupper():
                         is_valid.append(False)
                         
-
             if len(list(filter(lambda x: (x == False), is_valid))) > 0:    
                 yield errors.ForbiddenLabelError(note=note, 
-                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                row_numbers=list(range(1,len(headers)+1)),
                                                 label=header,
-                                                labels=list(row),
+                                                labels=headers,
                                                 field_number=field_number+1,
                                                 field_name=header)
+

--- a/ckanext/validation/ontario_data_standards/header_rule_2_4_first_char.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_4_first_char.py
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+from frictionless import Check, errors
+
+class header_rule_2_4_first_char(Check):
+    ''' 
+    Column headers must begin with an alphabetic letter. 
+    '''
+    Errors = [errors.ForbiddenLabelError]
+    def validate_row(self, row):
+        for field_number, header in enumerate(list(row)):
+            if not header[0].isalpha():
+                note = 'Column name must begin with an alphabetic letter.'
+                yield errors.ForbiddenLabelError(note=note, 
+                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                label=header,
+                                                labels=list(row),
+                                                field_number=field_number+1,
+                                                field_name=header)

--- a/ckanext/validation/ontario_data_standards/header_rule_2_4_first_char.py
+++ b/ckanext/validation/ontario_data_standards/header_rule_2_4_first_char.py
@@ -7,13 +7,14 @@ class header_rule_2_4_first_char(Check):
     Column headers must begin with an alphabetic letter. 
     '''
     Errors = [errors.ForbiddenLabelError]
-    def validate_row(self, row):
-        for field_number, header in enumerate(list(row)):
-            if not header[0].isalpha():
+    def validate_start(self):
+        headers = self.resource.labels
+        for field_number, header in enumerate(headers):
+            if len(header) > 0 and not header[0].isalpha():
                 note = 'Column name must begin with an alphabetic letter.'
                 yield errors.ForbiddenLabelError(note=note, 
-                                                row_numbers=list(range(1,len(list(row))+1)),
+                                                row_numbers=list(range(1,len(headers)+1)),
                                                 label=header,
-                                                labels=list(row),
+                                                labels=headers,
                                                 field_number=field_number+1,
                                                 field_name=header)

--- a/ckanext/validation/templates/scheming/form_snippets/resource_schema.html
+++ b/ckanext/validation/templates/scheming/form_snippets/resource_schema.html
@@ -1,8 +1,10 @@
 {% import 'macros/form.html' as form %}
 
   {% set value = data[field.field_name] %}
-  {% set is_url = value and value[4:]|lower == 'http' %}
-  {% set is_json = not is_url and value %}
+  {# % set is_url = value and value[4:]|lower == 'http' % #}
+  {# % set is_json = not is_url and value % #}
+  {% set is_url = 'http' in value %}
+  {% set is_json = not is_url %}
 
   <div class="image-upload"
        style="margin-bottom:20px"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
 ckantoolkit>=0.0.3
 frictionless==5.15.4
-markupsafe==2.0.1
 tableschema
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming
+Jinja2==3.0.3
+Werkzeug==2.0.3
+MarkupSafe==2.1.3
+itsdangerous==2.0.1
+Flask==1.1.1
+jsonschema==4.19.0
+jsonschema-specifications==2023.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.3
-frictionless==5.0.0b9
+frictionless==5.15.4
 markupsafe==2.0.1
 tableschema
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming


### PR DESCRIPTION
## What this PR accomplishes
First working draft for integrating ckanext-validation with the core CKAN dictionary form as used in ontario-theme. Specifically:
- hard-codes custom checks according to agreed data quality rules around header name syntax and length, and some data value rules (bare numbers, bullet lists)
- validates resources in two phases: 
    - Phase 1 occurs on file upload when xloader tries to push it to database. Checks performed include the hard-coded rules and any postgres violations around tabular structure (e.g. missing headers, shifted rows). (Note that postgres violation checks come for free with the process of xloader trying to push to database). In Phase 1, there is no data dictionary, therefore data types are not checked.
    - Phase 2 occurs when the Validate button on the data dictionary page is clicked. This is when data types are checked against the data dictionary inputs.

No modifications made to the UI of ckanext-validation itself, so validation message boxes and validation forms should all look the same.

## What needs review
- code logic
- functionality


## How to test
- refer to internal documentation on setting up this branch with custom edits to the frictionless package and the latest pull from xloader master branch
- upload csv files that contain various errors to test the checks in Phase 1 and 2. Check that the errors are caught and are displayed, and that validation passes once the errors are fixed.
- test four different scenarios: 
    Case 1: brand new resource on Phase 1 (i.e. when xloader tries to push to database)
    Case 2:  same resource after is has passed Phase 1; test Phase 2 against the data dictionary form
    Case 3: update an existing resource that does NOT have any data dictionary defined (i.e. replace csv file with a modified file but do not create any data dictionary form)
    Case 4: update an existing resource that DOES have a data dictionary defined