### PR TITLE
Error alert box style and content changes

### DIFF
--- a/ckanext/validation/helpers.py
+++ b/ckanext/validation/helpers.py
@@ -58,9 +58,8 @@ def validation_extract_report_from_errors(errors):
                 source = report['tables'][0]['source']
                 report['tables'][0]['source'] = source.split('/')[-1]
             msg = _('''
-There are validation issues with this file, please see the
-<a {params}>report</a> for details. Once you have resolved the issues,
-click the button below to replace the file.''')
+                    There is a problem with your data source. Please review the 
+                    <a {params}>validation report</a> to resolve the issues and try uploading again.''')
             params = [
                 'href="#validation-report"',
                 'data-module="modal-dialog"',

--- a/ckanext/validation/templates/scheming/snippets/errors.html
+++ b/ckanext/validation/templates/scheming/snippets/errors.html
@@ -2,98 +2,14 @@
 
 {% set validation_report, errors = h.validation_extract_report_from_errors(errors) %}
 {% block errors_list %}
-  <div class="ontario-alert ontario-alert--error">    
-      <div class="ontario-alert__header">
-        <div class="ontario-alert__header-icon">
-          <svg class="ontario-icon"
-                alt=""
-                aria-hidden="true"
-                focusable="false"
-                sol:category="primary"
-                viewBox="0 0 24 24"
-                preserveAspectRatio="xMidYMid meet">
-            <use href="#ontario-icon-alert-error"></use>
-          </svg>
-        </div>
-        <h2 class="ontario-alert__header-title ontario-h4">There is a problem</h2>
-      </div>
+  {{ super() }}
 
-    <ul>
-      {% block all_errors %}
-        {%- for field in fields -%}
-          {%- if 'error_snippet' in field -%}
-            {%- set error_snippet = field.error_snippet -%}
-
-            {%- if '/' not in error_snippet -%}
-              {%- set error_snippet = 'scheming/error_snippets/' +
-                error_snippet -%}
-            {%- endif -%}
-
-            {%- snippet error_snippet, unprocessed=unprocessed,
-              field=field, fields=fields,
-              entity_type=entity_type, object_type=object_type -%}
-          {%- endif -%}
-
-          {%- if field.field_name in unprocessed -%}
-            {%- set errors = unprocessed.pop(field.field_name) -%}
-            {%- if 'repeating_subfields' in field %}
-              {%- for se in errors -%}
-                {%- if se -%}
-                  <li data-field-label="{{ field.field_name }}-{{ loop.index }}">{{
-                    h.scheming_language_text(field.repeating_label or field.label) }}{{ loop.index }}:
-                    <ul>
-                      {%- for sf in field.repeating_subfields -%}
-                        {%- set se_unprocessed = se.copy() -%}
-
-                        {%- if 'error_snippet' in sf -%}
-                          {%- set sfe_snippet = sf.error_snippet -%}
-
-                          {%- if '/' not in sfe_snippet -%}
-                            {%- set sfe_snippet = 'scheming/error_snippets/' +
-                              sfe_snippet -%}
-                          {%- endif -%}
-
-                          {%- snippet sfe_snippet, unprocessed=se_unprocessed,
-                            field=sf, fields=field.repeating_subfileds,
-                            entity_type=entity_type, object_type=object_type -%}
-                        {%- endif -%}
-
-                        {%- if sf.field_name in se_unprocessed -%}
-                          <li data-field-label="{{ field.field_name }}-{{ loop.index }}-{{ sf.field_name }}">{{
-                            h.scheming_language_text(sf.label) }}:
-                            {{ se_unprocessed[sf.field_name][0] }}</li>
-                        {%- endif -%}
-                      {%- endfor -%}
-                    </ul>
-                  </li>
-                {%- endif -%}
-              {%- endfor -%}
-            {%- else -%}
-              {# Missing mandatory fields #}
-              <li data-field-label="{{ field.field_name }}">{{
-                h.scheming_language_text(field.label) }}:
-                {{ errors[0] }}</li>
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
-
-        {%- for key, errors in unprocessed.items() | sort -%}
-          {% if key == "validation" %}
-            <li data-field-label="{{ key }}">{{ errors[0] }}</li>
-          {% else %}
-            <li data-field-label="{{ key }}">{{ _(key) }}: {{ errors[0] }}</li>
-          {% endif %}
-        {%- endfor -%}
-      {% endblock %}
-    </ul>
-
-    {% if validation_report %}
-      {% if h.bootstrap_version() == '3' %}
-        {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=h.dump_json_value(validation_report) %}
-      {% else %}
-        {% snippet 'validation/snippets/validation_report_dialog_bs2.html', validation_report=h.dump_json_value(validation_report) %}
-      {% endif %}
+  {% if validation_report %}
+    {% if h.bootstrap_version() == '3' %}
+      {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=h.dump_json_value(validation_report) %}
+    {% else %}
+      {% snippet 'validation/snippets/validation_report_dialog_bs2.html', validation_report=h.dump_json_value(validation_report) %}
     {% endif %}
-  </div>
+  {% endif %}
 
 {% endblock %}

--- a/ckanext/validation/templates/scheming/snippets/errors.html
+++ b/ckanext/validation/templates/scheming/snippets/errors.html
@@ -2,14 +2,98 @@
 
 {% set validation_report, errors = h.validation_extract_report_from_errors(errors) %}
 {% block errors_list %}
-  {{ super() }}
+  <div class="ontario-alert ontario-alert--error">    
+      <div class="ontario-alert__header">
+        <div class="ontario-alert__header-icon">
+          <svg class="ontario-icon"
+                alt=""
+                aria-hidden="true"
+                focusable="false"
+                sol:category="primary"
+                viewBox="0 0 24 24"
+                preserveAspectRatio="xMidYMid meet">
+            <use href="#ontario-icon-alert-error"></use>
+          </svg>
+        </div>
+        <h2 class="ontario-alert__header-title ontario-h4">There is a problem</h2>
+      </div>
 
-  {% if validation_report %}
-    {% if h.bootstrap_version() == '3' %}
-      {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=h.dump_json_value(validation_report) %}
-    {% else %}
-      {% snippet 'validation/snippets/validation_report_dialog_bs2.html', validation_report=h.dump_json_value(validation_report) %}
+    <ul>
+      {% block all_errors %}
+        {%- for field in fields -%}
+          {%- if 'error_snippet' in field -%}
+            {%- set error_snippet = field.error_snippet -%}
+
+            {%- if '/' not in error_snippet -%}
+              {%- set error_snippet = 'scheming/error_snippets/' +
+                error_snippet -%}
+            {%- endif -%}
+
+            {%- snippet error_snippet, unprocessed=unprocessed,
+              field=field, fields=fields,
+              entity_type=entity_type, object_type=object_type -%}
+          {%- endif -%}
+
+          {%- if field.field_name in unprocessed -%}
+            {%- set errors = unprocessed.pop(field.field_name) -%}
+            {%- if 'repeating_subfields' in field %}
+              {%- for se in errors -%}
+                {%- if se -%}
+                  <li data-field-label="{{ field.field_name }}-{{ loop.index }}">{{
+                    h.scheming_language_text(field.repeating_label or field.label) }}{{ loop.index }}:
+                    <ul>
+                      {%- for sf in field.repeating_subfields -%}
+                        {%- set se_unprocessed = se.copy() -%}
+
+                        {%- if 'error_snippet' in sf -%}
+                          {%- set sfe_snippet = sf.error_snippet -%}
+
+                          {%- if '/' not in sfe_snippet -%}
+                            {%- set sfe_snippet = 'scheming/error_snippets/' +
+                              sfe_snippet -%}
+                          {%- endif -%}
+
+                          {%- snippet sfe_snippet, unprocessed=se_unprocessed,
+                            field=sf, fields=field.repeating_subfileds,
+                            entity_type=entity_type, object_type=object_type -%}
+                        {%- endif -%}
+
+                        {%- if sf.field_name in se_unprocessed -%}
+                          <li data-field-label="{{ field.field_name }}-{{ loop.index }}-{{ sf.field_name }}">{{
+                            h.scheming_language_text(sf.label) }}:
+                            {{ se_unprocessed[sf.field_name][0] }}</li>
+                        {%- endif -%}
+                      {%- endfor -%}
+                    </ul>
+                  </li>
+                {%- endif -%}
+              {%- endfor -%}
+            {%- else -%}
+              {# Missing mandatory fields #}
+              <li data-field-label="{{ field.field_name }}">{{
+                h.scheming_language_text(field.label) }}:
+                {{ errors[0] }}</li>
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+        {%- for key, errors in unprocessed.items() | sort -%}
+          {% if key == "validation" %}
+            <li data-field-label="{{ key }}">{{ errors[0] }}</li>
+          {% else %}
+            <li data-field-label="{{ key }}">{{ _(key) }}: {{ errors[0] }}</li>
+          {% endif %}
+        {%- endfor -%}
+      {% endblock %}
+    </ul>
+
+    {% if validation_report %}
+      {% if h.bootstrap_version() == '3' %}
+        {% snippet 'validation/snippets/validation_report_dialog.html', validation_report=h.dump_json_value(validation_report) %}
+      {% else %}
+        {% snippet 'validation/snippets/validation_report_dialog_bs2.html', validation_report=h.dump_json_value(validation_report) %}
+      {% endif %}
     {% endif %}
-  {% endif %}
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
## What this PR accomplishes
Changes the style of the error alert box on Step 1 of the new workflow to be consistent with the DS, and customizes the message content

## What needs review
Upload a file that contains invalid headers (e.g. duplicate headers or header names > 63 characters) and confirm that:
- alert box styling is consistent with DS
- alert box content shows a bullet list with one item and the content is: `There is a problem with your data source. Please review the validation report to resolve the issues and try uploading again.`
- the hyperlinked "validation report" opens the validation report modal, as before

Also check that the entire workflow works as expected once a fixed file has been uploaded.