### PR TITLE
rm hyperlink and hover text from badge

### DIFF
--- a/ckanext/validation/helpers.py
+++ b/ckanext/validation/helpers.py
@@ -2,7 +2,7 @@
 import json
 
 from ckan.lib.helpers import url_for_static
-from ckantoolkit import url_for, _, config, asbool, literal, h
+from ckantoolkit import _, config, asbool, literal, h
 
 
 def get_validation_badge(resource, in_listing=False):
@@ -26,22 +26,14 @@ def get_validation_badge(resource, in_listing=False):
     else:
         status = 'unknown'
 
-    validation_url = url_for(
-        'validation_read',
-        id=resource['package_id'],
-        resource_id=resource['id'])
-
     badge_url = url_for_static(
         '/images/badges/data-{}-flat.svg'.format(status))
 
     return '''
-<a href="{validation_url}" class="validation-badge">
-    <img src="{badge_url}" alt="{alt}" title="{title}"/>
-</a>'''.format(
-        validation_url=validation_url,
-        badge_url=badge_url,
-        alt=messages[status],
-        title=resource.get('validation_timestamp', ''))
+        <img class="validation-badge" src="{badge_url}" alt="{alt}">
+        '''.format(
+            badge_url=badge_url,
+            alt=messages[status])
 
 
 def validation_extract_report_from_errors(errors):


### PR DESCRIPTION
## What this PR accomplishes
Removes the hyperlink and hover from validation badges.

## What needs review
Verify that the validation badge can't be clicked on and that no hover text is displayed on mouse hover everywhere that the badge is displayed, i.e.:
- dataset page
- resource page
- during creation of a resource after Step 1 validation
