### PR TITLE
revert validation_read.html to original

### DIFF
--- a/ckanext/validation/templates/validation/validation_read.html
+++ b/ckanext/validation/templates/validation/validation_read.html
@@ -1,52 +1,51 @@
-{% extends "package/resource_edit_base.html" %}
+{% extends "package/base.html" %}
 
-{%- block subtitle %}{{ _('Validation Report') }}{% endblock subtitle -%}
 
+{%- block subtitle %}{{ _('Validation Report') }}{% endblock -%}
+
+{% block breadcrumb_content_selected %}{% endblock %}
 {% block breadcrumb_content %}
   {{ super() }}
-{% endblock breadcrumb_content %}
 
-{% block pre_primary %}  
-  {% set back_url = h.url_for(dataset.type ~ '_resource.edit', id=dataset.id, resource_id=resource.id) %}
-  {% snippet "package/snippets/step_indicator.html", step=2, back_url=back_url %}
-{% endblock pre_primary %}
+  <li><a href="{{ h.url_for('resource.read', id=dataset.id, resource_id=resource.id ) }}">{{ h.resource_display_name(resource)|truncate(30) }}</a></li>
+  <li class="active"><a href="">Validation Report</a></li>
+{% endblock %}
 
-{% block form_title %}
-  {{ h.resource_display_name(resource) | truncate(50) }}
-  {{ h.get_validation_badge(resource)|safe }}
-{% endblock form_title %}
+{% block pre_primary %}
 
-{# Temporary until edit_resource_base.html is modified #}
-{% block page_header %}{% endblock page_header%}
+    <section class="module module-validation">
+      <div class="module-content">
+        <div class="actions">
 
-{% block primary_content_inner %}
-  <div class="validation-details">          
-      <div>{{ _('Validation timestamp') }}: {{ h.render_datetime(resource.validation_timestamp, with_hours=True) }}</div>
-      {% if validation.report %}
-      <div>{{ _('Duration') }}: {{ h.validation_dict(validation.report)["stats"]["seconds"] }}s</div>
-      {% endif %}
-  </div>
-  {% if validation.report %}
-      <div class="ontario-alert ontario-alert--success">
-        <div class="ontario-alert__header">
-            <div class="ontario-alert__header-icon">
-                <svg class="ontario-icon" alt="" aria-hidden="true" focusable="false" sol:category="primary" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet">
-                    <use href="#ontario-icon-alert-success"></use>
-                </svg>
-            </div>
-            <h2 class="ontario-alert__header-title ontario-h4">Data validated successfully</h2>
         </div>
-    </div> 
-  {% endif %}
 
-  {% set package_id = resource.get('package_id') %}
-  {% set resource_id = resource.get('id') %}
-  {% set action = h.url_for('datastore.dictionary',
-            id=package_id,
-            resource_id=resource.id) %}
-  
-  <form method="get" action="{{ action }}" >
-    <button class="ontario-button ontario-button--primary" name="save" type="submit">Continue</button>
-  </form>
+        <h1 class="page-heading">{{ h.resource_display_name(resource) | truncate(50) }}
+        {{ h.get_validation_badge(resource)|safe }}
+        </h1>
 
-{% endblock primary_content_inner %}
+        <div class="validation-details">
+            <div>{{ _('Validation timestamp') }}: {{ h.render_datetime(resource.validation_timestamp, with_hours=True) }}</div>
+            {% if validation.report %}
+            <div>{{ _('Duration') }}: {{ h.validation_dict(validation.report)["stats"]["seconds"] }}s</div>
+            {% endif %}
+        </div>
+
+        {% if validation.report %}
+            <div id="report" {% if h.bootstrap_version() == '2' %}class="bs2"{% endif %} data-module="validation-report" data-module-report="{{ validation.report }}"></div>
+        {% endif %}
+
+      </div>
+    </section>
+{% if h.use_webassets() %}
+    {% snippet 'validation/snippets/validation_asset.html', name='ckanext-validation/report-css' %}
+    {% snippet 'validation/snippets/validation_asset.html', name='ckanext-validation/report-js' %}
+{% else %}
+    {% snippet 'validation/snippets/validation_resource.html', name='ckanext-validation/report' %}
+{% endif %}
+
+{% endblock %}
+
+
+{% block primary %}{% endblock %}
+
+{% block secondary %}{% endblock %}


### PR DESCRIPTION
## What this PR accomplishes
Reverts `validation_read.html` to the original. Modifications are no longer necessary in this extension since they are handled in the ontario theme extension ([PR562](https://github.com/ongov/ckanext-ontario_theme/pull/562)).

## What needs review
**~~Note: please review only after https://github.com/ongov/ckanext-ontario_theme/pull/562 is merged~~** PR is merged
Check that the error alert is displayed as expected when a CSV file with a header or table violation is uploaded as a new resource (e.g. duplicate column header).
![Screenshot 2024-05-01 at 10 34 06](https://github.com/ongov/ckanext-validation/assets/1254764/1b86eaf0-2337-4a88-98e2-097f7dcb65bb)
