### PR TITLE
rm hyphen from bullet list check

### DIFF
--- a/ckanext/validation/ontario_data_standards/data_entry_rule_2_6_bullet_lists.py
+++ b/ckanext/validation/ontario_data_standards/data_entry_rule_2_6_bullet_lists.py
@@ -12,7 +12,7 @@ class data_entry_rule_2_6_bullet_lists(Check):
         for header in list(row):
             this_cell = row[header]
             if isinstance(this_cell, str):
-                list_chars = [u'•', u'* ', u'- ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash
+                list_chars = [u'•', u'* ', u'â€”', u'\n',  u'\t'] # u'â€”' is em-dash. Excludes dash u'- '
                 bullet_check = [ele for ele in list_chars if(ele in this_cell.rstrip())] # strip any trailing spaces
                 if len(bullet_check) > 0:
                     note = 'Cell value cannot contain bullets, dashes, new line or tab characters. Please make separate rows.'


### PR DESCRIPTION
## What this PR accomplishes
In the bullet list check, simply checking if a hyphen exists will flag entries that are not actually bullet lists. Better to rely on the new line or tab characters to distinguish a list from a hyphen inside a line of text.

Not the greatest but this will do for now as otherwise most files will fail.


## What needs review
Pass in a file with an actual bullet list vs a file that has one line that contains a hyphen.