### PR TITLE
add duplicate row check from frictionless check library

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -6,7 +6,7 @@ import json
 
 import requests
 from sqlalchemy.orm.exc import NoResultFound
-from frictionless import validate, system, Report, Schema, Dialect, Check, errors
+from frictionless import validate, system, Report, Schema, Dialect, Check, checks
 from ckanext.validation.ontario_data_standards.header_rule_2_2_header_length import header_rule_2_2_header_length
 from ckanext.validation.ontario_data_standards.header_rule_2_3_snake_case import header_rule_2_3_snake_case
 from ckanext.validation.ontario_data_standards.header_rule_2_4_first_char import header_rule_2_4_first_char
@@ -170,7 +170,8 @@ def _validate_table(source, _format='csv', schema=None, **options):
                           schema=resource_schema,
                           checks=[header_rule_2_2_header_length(),
                                   header_rule_2_4_first_char(),
-                                  data_entry_rule_2_6_bullet_lists()
+                                  data_entry_rule_2_6_bullet_lists(),
+                                  checks.duplicate_row()
                                  ])
         log.debug('Validating source: %s', source)
 


### PR DESCRIPTION
## What this PR accomplishes
Adds the duplicate row check available from the frictionless library: https://framework.frictionlessdata.io/docs/checks/row.html#duplicate-row

## What needs review
Upload a file containing one or more duplicate rows and test that these are flagged.