### PR TITLE
Patch: do not delete invalid resource from FileStore

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -680,15 +680,8 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
         report = json.loads(validation['report'])
 
         if not report['valid']:
-            # Delete validation object
-            t.get_action(u'resource_validation_delete')(
-                {u'ignore_auth': True},
-                {u'resource_id': resource_id}
-            )
-
-            # Delete uploaded file
-            if local_upload:
-                delete_local_uploaded_file(resource_id)
+            # Do not delete validation object
+            # Do not delete uploaded file
 
             if new_resource:
                 try:


### PR DESCRIPTION
## What this PR accomplishes
Removes code that deletes invalid csv files from FileStore when they are uploaded to replace an existing resource.

## What needs review
Must be reviewed together with https://github.com/ongov/ckanext-ontario_theme/pull/615. 