### PR TITLE
Checks if resource exists in datastore before running validation

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -626,7 +626,7 @@ def resource_update(up_func, context, data_dict):
             hasattr(upload, 'filename') and
             upload.filename is not None and
             isinstance(upload, uploader.ResourceUpload))
-        if resource['format'] == 'CSV':
+        if resource['format'] == 'CSV' and resource['datastore_active']:
             _run_sync_validation(
                 id, local_upload=is_local_upload, new_resource=False)
         else:


### PR DESCRIPTION
## What this PR accomplishes
Works together with https://github.com/ongov/ckanext-ontario_theme/pull/619.

Because existing CSV resources on the catalogue have never been through validation, some may not actually be in the datastore. If these existing but not-existing-in-datastore CSV resources get sent for validation, an error will occur since validation calls the resource from the datastore (e.g. https://github.com/ongov/ckanext-validation/blob/develop/ckanext/validation/logic.py#L88). 

The solution is to check if an existing CSV resource exists in the datastore before sending it for validation.

## Issue(s) resolved
DATA-1630

## What needs review
- Run tests on existing CSV resources that are not in the catalogue (these are usually remote WEB or remote CSV resources)
- Check that regular sanity tests pass (on local and remote file types)