### PR TITLE
bypass remote CSVs for new and existing

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -502,8 +502,9 @@ def resource_create(up_func, context, data_dict):
             hasattr(upload, 'filename') and
             upload.filename is not None and
             isinstance(upload, uploader.ResourceUpload))
-        _run_sync_validation(
-            resource_id, local_upload=is_local_upload, new_resource=True)
+        if is_local_upload:
+            _run_sync_validation(
+                resource_id, local_upload=is_local_upload, new_resource=True)
 
     # Custom code ends
 
@@ -626,11 +627,16 @@ def resource_update(up_func, context, data_dict):
             hasattr(upload, 'filename') and
             upload.filename is not None and
             isinstance(upload, uploader.ResourceUpload))
-        if resource['format'] == 'CSV' and resource['datastore_active']:
-            _run_sync_validation(
-                id, local_upload=is_local_upload, new_resource=False)
+        if is_local_upload:
+            if resource['format'] == 'CSV' and resource['datastore_active']:
+                _run_sync_validation(
+                    id, local_upload=is_local_upload, new_resource=False)
+            else:
+                msg = 'Resource {} is not a CSV file. No validation performed'.format(
+                    id)
+                log.info(msg)
         else:
-            msg = 'Resource {} is not a CSV file. No validation performed'.format(
+            msg = 'Resource {} is remote. No validation performed'.format(
                 id)
             log.info(msg)
 


### PR DESCRIPTION
## What this PR accomplishes
Does not send remote CSVs for validation when either creating a new resource or updating an existing resource.

## Issue(s) addressed
DATA-1639

## What needs review
Test that remote CSVs do not get sent for validation when either creating a new resource or updating an existing resource. Also do the regular tests to make sure this fix does not break anything.